### PR TITLE
Update nodejs base image 12 to 22.13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,48 @@
-FROM node:22.13.1-alpine
+FROM node:22-alpine
 
-ENV FFMPEG_VERSION=4.2.1
+ENV FFMPEG_VERSION=7.0.2
 
 WORKDIR /tmp/ffmpeg
 
+# Install build dependencies
 RUN apk add --no-cache \
-    --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
-    fdk-aac-dev && \
+  --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
+  fdk-aac-dev && \
   apk add --no-cache --update \
-    build-base curl tar bzip2 zlib-dev \
-    automake \
-    autoconf \
-    coreutils \
-    nasm \
-    file \
-    libpng-dev \
-    make \
-    bash \
-    git \
-    python3 \
-    g++ \
-    imagemagick \
-    gettext \
-    librsvg && \
-  apk add --no-cache \
-    --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
-    graphicsmagick && \
+  build-base curl tar bzip2 zlib-dev \
+  automake \
+  autoconf \
+  coreutils \
+  nasm \
+  file \
+  libpng-dev \
+  make \
+  bash \
+  git \
+  python3 \
+  g++ \
+  imagemagick \
+  gettext \
+  librsvg
 
-  DIR=$(mktemp -d) && cd ${DIR} && \
+# Install graphicsmagick from the edge repository
+RUN apk add --no-cache \
+  --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
+  graphicsmagick
 
-  curl -s http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz | tar zxvf - -C . && \
+# Download FFmpeg source with HTTPS and check the contents
+RUN DIR=$(mktemp -d) && cd ${DIR} && \
+  curl -sL "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz" -o ffmpeg-${FFMPEG_VERSION}.tar.gz && \
+  echo "Downloaded file:" && ls -l ffmpeg-${FFMPEG_VERSION}.tar.gz && \
+  file ffmpeg-${FFMPEG_VERSION}.tar.gz && \
+  tar -xvf ffmpeg-${FFMPEG_VERSION}.tar.gz && \
   cd ffmpeg-${FFMPEG_VERSION} && \
   ./configure --enable-version3 --enable-gpl --enable-nonfree --enable-small --enable-libfdk-aac --disable-debug && \
   make && \
   make install && \
-  make distclean && \
+  make distclean
 
-  rm -rf ${DIR} && \
-  apk del build-base curl tar bzip2 && rm -rf /var/cache/apk/*
+# Clean up temporary files and unnecessary packages
+RUN rm -rf ${DIR} && \
+  apk del build-base curl tar bzip2 && \
+  rm -rf /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:22.13.1-alpine
 
 ENV FFMPEG_VERSION=4.2.1
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,9 +1,12 @@
 # WishYoo Base
-
 Base container image for chantr dev repositories.
 
-## Building
+## Versions
+- Node.js: 22.13.1
+- FFmpeg: 7.0.2
 
+## Building the Image
+To build the Docker image, Run command given below:
 ```bash
 docker build -t wishyoo-base .
 ```


### PR DESCRIPTION
Update nodejs base image 12 to 22.13.1

Issue : https://github.com/WebResources/chantr-api/issues/1418 for chantr-api